### PR TITLE
Ability to JSON encode attachments when present.

### DIFF
--- a/django_slack/api.py
+++ b/django_slack/api.py
@@ -1,3 +1,4 @@
+import json
 from django.conf import settings
 from django.template import Context
 from django.template.loader import render_to_string
@@ -55,7 +56,7 @@ def slack_message(template, context=None, attachments=None, fail_silently=app_se
         assert False, "Missing or empty required parameter: %s" % x
 
     if attachments:
-        data['attachments'] = attachments
+        data['attachments'] = json.dumps(attachments)
 
     try:
         backend.send('https://slack.com/api/chat.postMessage', data)

--- a/django_slack/api.py
+++ b/django_slack/api.py
@@ -1,4 +1,5 @@
 import json
+
 from django.conf import settings
 from django.template import Context
 from django.template.loader import render_to_string


### PR DESCRIPTION
Helps #4.

Given that an attachments value will contain a data structure other
than a string. It is necessary for the value to be JSON encoded in
order to be parsed correctly by Slack’s chat.postMessage API.