### PR TITLE
Fix to ensure proper encoding of attachments.

### DIFF
--- a/django_slack/api.py
+++ b/django_slack/api.py
@@ -65,6 +65,9 @@ def slack_message(template, context=None, attachments=None, fail_silently=app_se
 
     # If a custom endpoint URL was specified then we need to wrap it
     if endpoint_url != app_settings.DEFAULT_ENDPOINT_URL:
+        if attachments is not None:
+            data['attachments'] = attachments
+
         data = {'payload': json.dumps(data)}
 
     try:


### PR DESCRIPTION
Addresses #23

While not ideal in logical flow. It does achieve the goal of ensuring
the payload does not encode attachments twice.