### PR TITLE
Do not create a Context instance.

### DIFF
--- a/django_slack/api.py
+++ b/django_slack/api.py
@@ -11,8 +11,10 @@ backend = from_dotted_path(app_settings.BACKEND)()
 def slack_message(template, context=None, attachments=None, fail_silently=app_settings.FAIL_SILENTLY):
     data = {}
 
+    # The context passed into each template.
     context_base = {'settings': settings}
-    if context:
+    # Update this with the passed in context, if provided.
+    if context is not None:
         context_base.update(context)
 
     for k, v in {
@@ -58,6 +60,7 @@ def slack_message(template, context=None, attachments=None, fail_silently=app_se
         # Render template if necessary
         if v.get('render', True):
             try:
+                # Create a context just for this template.
                 temp_context = {
                     'django_slack': 'django_slack/%s' % k,
                 }

--- a/django_slack/api.py
+++ b/django_slack/api.py
@@ -1,7 +1,6 @@
 import json
 
 from django.conf import settings
-from django.template import Context
 from django.template.loader import render_to_string
 
 from . import app_settings
@@ -12,8 +11,9 @@ backend = from_dotted_path(app_settings.BACKEND)()
 def slack_message(template, context=None, attachments=None, fail_silently=app_settings.FAIL_SILENTLY):
     data = {}
 
-    context = Context(context or {})
-    context['settings'] = settings
+    context_base = {'settings': settings}
+    if context:
+        context_base.update(context)
 
     for k, v in {
         'text': {
@@ -58,9 +58,11 @@ def slack_message(template, context=None, attachments=None, fail_silently=app_se
         # Render template if necessary
         if v.get('render', True):
             try:
-                val = render_to_string(template, {
+                temp_context = {
                     'django_slack': 'django_slack/%s' % k,
-                }, context).strip().encode('utf8', 'ignore')
+                }
+                temp_context.update(context_base)
+                val = render_to_string(template, temp_context).strip().encode('utf8', 'ignore')
             except Exception:
                 if fail_silently:
                     return


### PR DESCRIPTION
Fixes #30 

This stops creating a `Context` instance and just passes a `dict` into the `context` `kwarg`, as suggested by [the docs](https://docs.djangoproject.com/en/1.9/topics/templates/#django.template.loader.render_to_string).