### PR TITLE
support another job queue  python-rq

### DIFF
--- a/django_slack/app_settings.py
+++ b/django_slack/app_settings.py
@@ -18,9 +18,11 @@ class AppSettings(object):
     ICON_EMOJI = setting('ICON_EMOJI', None)
 
     ENDPOINT_URL = setting('ENDPOINT_URL', DEFAULT_ENDPOINT_URL)
+    DEFAULT_QUEUE_NAME = "default" # used for async queue
 
     BACKEND = setting('BACKEND', DEFAULT_BACKEND)
     BACKEND_FOR_QUEUE = setting('BACKEND_FOR_QUEUE', DEFAULT_BACKEND)
+    BACKEND_QUEUE_NAME = setting('BACKEND_QUEUE_NAME', DEFAULT_QUEUE_NAME)
 
     FAIL_SILENTLY = setting('FAIL_SILENTLY', False)
 

--- a/django_slack/backends.py
+++ b/django_slack/backends.py
@@ -47,11 +47,10 @@ class DisabledBackend(Backend):
     def send(self, url, data, **kwargs):
         pass
 
-class CeleryBackend(Backend):
+
+class _AsyncBackend(Backend):
     def __init__(self):
-        # Lazily import to avoid dependency
-        from .tasks import send
-        self._send = send
+        self._send = self.init_sender()
 
         # Check we can import our specified backend up-front
         import_string(app_settings.BACKEND_FOR_QUEUE)()
@@ -59,5 +58,25 @@ class CeleryBackend(Backend):
     def send(self, *args, **kwargs):
         # Send asynchronously via Celery
         self._send.delay(*args, **kwargs)
+
+    def init_sender(self):
+        # Lazily import to avoid dependency
+        # subclass this must implement this method
+        raise NotImplementedError()
+
+
+class CeleryBackend(_AsyncBackend):
+
+    def init_sender(self):
+        from .tasks import get_celery_task
+        return get_celery_task()
+
+
+class RQBackend(_AsyncBackend):
+
+    def init_sender(self):
+        from .tasks import get_rq_worker
+        return get_rq_worker()
+
 
 Urllib2Backend = UrllibBackend # For backwards-compatibility

--- a/django_slack/tasks.py
+++ b/django_slack/tasks.py
@@ -1,9 +1,18 @@
-from celery import task
-
 from django.utils.module_loading import import_string
 
 from .app_settings import app_settings
 
-@task
-def send(*args, **kwargs):
+
+def _sender(*args, **kwargs):
     return import_string(app_settings.BACKEND_FOR_QUEUE)().send(*args, **kwargs)
+
+
+def get_celery_task():
+    from celery import task
+    return task(_sender)
+
+
+def get_rq_task(connection=None):
+    from rq.decorators import job
+    from django_rq.queues import get_queue
+    return job(queue=get_queue(app_settings.BACKEND_QUEUE_NAME))(_sender)


### PR DESCRIPTION
I don’t use celery current now, instead I use python-rq which is simpler  and lighter than Celery. 

So, I added this patch , hope someone like me using rq as well will take advantage of it.