### PR TITLE
fixed unicode when we do urlencode

### DIFF
--- a/django_slack/backends.py
+++ b/django_slack/backends.py
@@ -4,6 +4,7 @@ import logging
 from six.moves import urllib
 
 from django.utils.module_loading import import_string
+from django.http.request import QueryDict
 
 from .utils import Backend
 from .app_settings import app_settings
@@ -12,9 +13,11 @@ logger = logging.getLogger(__name__)
 
 class UrllibBackend(Backend):
     def send(self, url, data, **kwargs):
+        qs = QueryDict(mutable=True)
+        qs.update(data)
         r = urllib.request.urlopen(urllib.request.Request(
             url,
-            urllib.parse.urlencode(data).encode('utf-8'),
+            qs.urlencode().encode('utf-8'),
         ))
 
         result = r.read().decode('utf-8')


### PR DESCRIPTION
I got unicode encode error when urlencode my data dict , which of course have some unicode characters. 

Since urlencode don't like unicodes and Django QueryDict already done a lot of string types convert work. I suggest to use QueryDict to get our urlencode string is a good choice.