### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Django >= 1.6.8
+Django >= 1.7
 requests
 six


### PR DESCRIPTION
Minimal supported Django version = 1.7

Because of this import:
`from django.utils.module_loading import import_string`