### PR TITLE
Clarify _which_ channel wasn't found

### DIFF
--- a/django_slack/backends.py
+++ b/django_slack/backends.py
@@ -13,9 +13,9 @@ logger = logging.getLogger(__name__)
 
 
 class UrllibBackend(Backend):
-    def send(self, url, data, **kwargs):
+    def send(self, url, message_data, **kwargs):
         qs = QueryDict(mutable=True)
-        qs.update(data)
+        qs.update(message_data)
 
         r = urllib.request.urlopen(urllib.request.Request(
             url,
@@ -24,7 +24,7 @@ class UrllibBackend(Backend):
 
         result = r.read().decode('utf-8')
 
-        self.validate(r.headers['content-type'], result, data)
+        self.validate(r.headers['content-type'], result, message_data)
 
 
 class RequestsBackend(Backend):
@@ -34,26 +34,26 @@ class RequestsBackend(Backend):
 
         self.session = requests.Session()
 
-    def send(self, url, data, **kwargs):
-        r = self.session.post(url, data=data, verify=False)
+    def send(self, url, message_data, **kwargs):
+        r = self.session.post(url, data=message_data, verify=False)
 
-        self.validate(r.headers['Content-Type'], r.text, data)
+        self.validate(r.headers['Content-Type'], r.text, message_data)
 
 
 class ConsoleBackend(Backend):
-    def send(self, url, data, **kwargs):
+    def send(self, url, message_data, **kwargs):
         print("I: Slack message:")
-        pprint.pprint(data, indent=4)
+        pprint.pprint(message_data, indent=4)
         print("-" * 79)
 
 
 class LoggerBackend(Backend):
-    def send(self, url, data, **kwargs):
-        logger.info(pprint.pformat(data, indent=4))
+    def send(self, url, message_data, **kwargs):
+        logger.info(pprint.pformat(message_data, indent=4))
 
 
 class DisabledBackend(Backend):
-    def send(self, url, data, **kwargs):
+    def send(self, url, message_data, **kwargs):
         pass
 
 
@@ -84,8 +84,8 @@ class TestBackend(Backend):
         super().__init__(*args, **kwargs)
         self.reset_messages()
 
-    def send(self, url, data, **kwargs):
-        self.messages.append(data)
+    def send(self, url, message_data, **kwargs):
+        self.messages.append(message_data)
 
     def reset_messages(self):
         self.messages = []

--- a/django_slack/backends.py
+++ b/django_slack/backends.py
@@ -24,7 +24,7 @@ class UrllibBackend(Backend):
 
         result = r.read().decode('utf-8')
 
-        self.validate(r.headers['content-type'], result)
+        self.validate(r.headers['content-type'], result, data)
 
 
 class RequestsBackend(Backend):
@@ -37,7 +37,7 @@ class RequestsBackend(Backend):
     def send(self, url, data, **kwargs):
         r = self.session.post(url, data=data, verify=False)
 
-        self.validate(r.headers['Content-Type'], r.text)
+        self.validate(r.headers['Content-Type'], r.text, data)
 
 
 class ConsoleBackend(Backend):

--- a/django_slack/exceptions.py
+++ b/django_slack/exceptions.py
@@ -10,6 +10,8 @@ class SlackException(ValueError):
 @six.python_2_unicode_compatible
 class ChannelNotFound(SlackException):
     def __str__(self):
+        # Override base __str__ to ensure we include the channel name in the
+        # error message
         return u"{}: channel '{}' could not be found".format(
             self.__class__.__name__,
             self.sent_data['channel'],

--- a/django_slack/exceptions.py
+++ b/django_slack/exceptions.py
@@ -1,9 +1,19 @@
+import six
+
+
 class SlackException(ValueError):
-    pass
+    def __init__(self, message, sent_data):
+        super(SlackException, self).__init__(message)
+        self.sent_data = sent_data
 
 
+@six.python_2_unicode_compatible
 class ChannelNotFound(SlackException):
-    pass
+    def __str__(self):
+        return u"{}: channel '{}' could not be found".format(
+            self.__class__.__name__,
+            self.sent_data['channel'],
+        )
 
 
 class IsArchived(SlackException):

--- a/django_slack/exceptions.py
+++ b/django_slack/exceptions.py
@@ -2,9 +2,9 @@ import six
 
 
 class SlackException(ValueError):
-    def __init__(self, message, sent_data):
+    def __init__(self, message, message_data):
         super(SlackException, self).__init__(message)
-        self.sent_data = sent_data
+        self.message_data = message_data
 
 
 @six.python_2_unicode_compatible
@@ -14,7 +14,7 @@ class ChannelNotFound(SlackException):
         # error message
         return u"{}: channel '{}' could not be found".format(
             self.__class__.__name__,
-            self.sent_data['channel'],
+            self.message_data['channel'],
         )
 
 

--- a/django_slack/utils.py
+++ b/django_slack/utils.py
@@ -10,14 +10,14 @@ class Backend(object):
     def send(self, url, data):
         raise NotImplementedError()
 
-    def validate(self, content_type, content):
+    def validate(self, content_type, content, original_data):
         if content_type.startswith('application/json'):
             result = json.loads(content)
 
             if not result['ok']:
                 klass = LABEL_TO_EXCEPTION.get(result['error'], SlackException)
 
-                raise klass(result['error'])
+                raise klass(result['error'], original_data)
 
         elif content != 'ok':
             raise SlackException(content)

--- a/django_slack/utils.py
+++ b/django_slack/utils.py
@@ -7,17 +7,17 @@ from .app_settings import app_settings
 
 
 class Backend(object):
-    def send(self, url, data):
+    def send(self, url, message_data):
         raise NotImplementedError()
 
-    def validate(self, content_type, content, original_data):
+    def validate(self, content_type, content, message_data):
         if content_type.startswith('application/json'):
             result = json.loads(content)
 
             if not result['ok']:
                 klass = LABEL_TO_EXCEPTION.get(result['error'], SlackException)
 
-                raise klass(result['error'], original_data)
+                raise klass(result['error'], message_data)
 
         elif content != 'ok':
             raise SlackException(content)

--- a/tests/backends.py
+++ b/tests/backends.py
@@ -14,10 +14,10 @@ class StorageBackend(Backend):
         """
         self.messages = []
 
-    def send(self, url, data):
+    def send(self, url, message_data):
         self.messages.append({
             'url': url,
-            'data': data,
+            'message_data': message_data,
         })
 
 class RaisingBackend(Backend):
@@ -27,5 +27,5 @@ class RaisingBackend(Backend):
     class RaisedException(Exception):
         pass
 
-    def send(self, url, data):
-        raise RaisingBackend.RaisedException(url, data)
+    def send(self, url, message_data):
+        raise RaisingBackend.RaisedException(url, message_data)

--- a/tests/test_escaping.py
+++ b/tests/test_escaping.py
@@ -25,7 +25,7 @@ class SlackTestCase(unittest.TestCase):
 
         # Ensure each input value in data.
         for kwarg, value in kwargs.items():
-            self.assertEqual(value, message['data'][kwarg])
+            self.assertEqual(value, message['message_data'][kwarg])
 
 class TestEscaping(SlackTestCase):
     def test_simple_message(self):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,37 @@
+import json
+from django.conf import settings
+from django.test import TestCase, override_settings
+
+from django_slack.exceptions import ChannelNotFound, MsgTooLong
+from django_slack.backends import Backend
+
+
+class TestOverride(TestCase):
+    def test_ok_result(self):
+        backend = Backend()
+        backend.validate('application/json', json.dumps({'ok': True}), {})
+
+    def test_msg_too_long_result(self):
+        # Arbitrarily chosen 'simple' error
+        backend = Backend()
+        with self.assertRaises(
+            MsgTooLong,
+            expected_regexp=r"MsgTooLong: msg_too_long",
+        ):
+            backend.validate(
+                'application/json',
+                json.dumps({'ok': False, 'error': 'msg_too_long'}),
+                {},
+            )
+
+    def test_channel_not_found_result(self):
+        backend = Backend()
+        with self.assertRaises(
+            ChannelNotFound,
+            expected_regexp=r"ChannelNotFound: channel 'bad-channel' could not be found",
+        ):
+            backend.validate(
+                'application/json',
+                json.dumps({'ok': False, 'error': 'channel_not_found'}),
+                {'channel': 'bad-channel'},
+            )

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,6 +1,6 @@
 import json
-from django.conf import settings
-from django.test import TestCase, override_settings
+
+from django.test import TestCase
 
 from django_slack.exceptions import ChannelNotFound, MsgTooLong
 from django_slack.backends import Backend


### PR DESCRIPTION
We have the data for this, it's just not being passed around at the moment.

Note: this change is breaking for anyone who has subclassed the exceptions this project defines or has created their own backend and is using the '.validate' method.

I'm open to rewriting this in a non-breaking way if that's strongly desired.