### PR TITLE
Instantiation of SlackException requires argument 'message_data'

### DIFF
--- a/django_slack/utils.py
+++ b/django_slack/utils.py
@@ -20,7 +20,7 @@ class Backend(object):
                 raise klass(result['error'], message_data)
 
         elif content != 'ok':
-            raise SlackException(content)
+            raise SlackException(content, message_data)
 
 
 def get_backend(name=None):


### PR DESCRIPTION
Omitting it leads to a `TypeError`.

Broken in https://github.com/lamby/django-slack/commit/0dfc8d10857d60a4bf95716551f95f7a1c77b25b#diff-81a638ea9025632b2a95b6f35f70a5d7R5 (part of PR lamby/django-slack#70)