### PR TITLE
Remove insecure requests defaults

### DIFF
--- a/django_slack/backends.py
+++ b/django_slack/backends.py
@@ -35,7 +35,7 @@ class RequestsBackend(Backend):
         self.session = requests.Session()
 
     def send(self, url, message_data, **kwargs):
-        r = self.session.post(url, data=message_data, verify=False)
+        r = self.session.post(url, data=message_data)
 
         self.validate(r.headers['Content-Type'], r.text, message_data)
 


### PR DESCRIPTION
django-slack used to skip verification of ssl certificates in requests,
which nullifies a large part of tls.

This commit reenables ssl certificate validation.