### PR TITLE
Update api.py

### DIFF
--- a/django_slack/api.py
+++ b/django_slack/api.py
@@ -14,7 +14,7 @@ def slack_message(
     attachments=None,
     blocks=None,
     fail_silently=None,
-    **kwargs,
+    **kwargs
 ):
     data = {}
 


### PR DESCRIPTION
I received the following error when using the latest version of django-slack with python 3.5.3 on Debian (in a virtual environment):

File "######/lib/python3.5/site-packages/django_slack/api.py", line 17
    **kwargs,
            ^
SyntaxError: invalid syntax

The error disappeared after I edited my local version of api.py to remove the comma after **kwargs