### PR TITLE
Fix force_text to force_str

### DIFF
--- a/django_slack/api.py
+++ b/django_slack/api.py
@@ -1,7 +1,7 @@
 import json
 
 from django.conf import settings
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.template.loader import render_to_string
 
 from .utils import get_backend
@@ -76,7 +76,7 @@ def slack_message(
         # Render template if necessary
         if v.get('render', True):
             try:
-                val = force_text(
+                val = force_str(
                     render_to_string(
                         template,
                         dict(

--- a/django_slack/templatetags/django_slack.py
+++ b/django_slack/templatetags/django_slack.py
@@ -1,7 +1,7 @@
 import six
 
 from django import template
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.safestring import SafeText, mark_safe
 from django.template.defaultfilters import stringfilter
 
@@ -29,7 +29,7 @@ def escapeslack(value):
 
     This is based on django.template.defaultfilters.escapejs.
     """
-    return mark_safe(force_text(value).translate(_slack_escapes))
+    return mark_safe(force_str(value).translate(_slack_escapes))
 
 
 escapeslack = allow_lazy(escapeslack, six.text_type, SafeText)


### PR DESCRIPTION
`force_text()` is deprecated in favor of `force_str()`

`force_text` removed in Django 4