### PR TITLE
Cleanup after drop of support for Python 2 and Django 1.x

### DIFF
--- a/django_slack/backends.py
+++ b/django_slack/backends.py
@@ -1,7 +1,6 @@
 import pprint
 import logging
-
-from six.moves import urllib
+import urllib.request
 
 from django.http.request import QueryDict
 from django.utils.module_loading import import_string

--- a/django_slack/exceptions.py
+++ b/django_slack/exceptions.py
@@ -1,13 +1,9 @@
-import six
-
-
 class SlackException(ValueError):
     def __init__(self, message, message_data):
         super(SlackException, self).__init__(message)
         self.message_data = message_data
 
 
-@six.python_2_unicode_compatible
 class ChannelNotFound(SlackException):
     def __str__(self):
         # Override base __str__ to ensure we include the channel name in the

--- a/django_slack/templatetags/django_slack.py
+++ b/django_slack/templatetags/django_slack.py
@@ -1,5 +1,3 @@
-import six
-
 from django import template
 from django.utils.encoding import force_str
 from django.utils.safestring import SafeText, mark_safe
@@ -32,4 +30,4 @@ def escapeslack(value):
     return mark_safe(force_str(value).translate(_slack_escapes))
 
 
-escapeslack = allow_lazy(escapeslack, six.text_type, SafeText)
+escapeslack = allow_lazy(escapeslack, str, SafeText)

--- a/django_slack/templatetags/django_slack.py
+++ b/django_slack/templatetags/django_slack.py
@@ -1,12 +1,8 @@
 from django import template
 from django.utils.encoding import force_str
+from django.utils.functional import keep_lazy
 from django.utils.safestring import SafeText, mark_safe
 from django.template.defaultfilters import stringfilter
-
-try:
-    from django.utils.functional import keep_lazy as allow_lazy
-except ImportError:
-    from django.utils.functional import allow_lazy
 
 register = template.Library()
 
@@ -17,6 +13,7 @@ _slack_escapes = {
 }
 
 
+@keep_lazy(str, SafeText)
 @register.filter(is_safe=True)
 @stringfilter
 def escapeslack(value):
@@ -28,6 +25,3 @@ def escapeslack(value):
     This is based on django.template.defaultfilters.escapejs.
     """
     return mark_safe(force_str(value).translate(_slack_escapes))
-
-
-escapeslack = allow_lazy(escapeslack, str, SafeText)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-Django >= 1.7
+Django>=2.0
 requests
-six

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,6 @@ setup(
     license="BSD-3-Clause",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=('Django>=2', 'requests', 'six',),
+    python_requires=">=3.5",
+    install_requires=('Django>=2', 'requests'),
 )


### PR DESCRIPTION
- Drop `six` as a requirement
- Make Python 3.5 a hard requirement
- Remove compatibility code for Django<1.10