### PR TITLE
Make compatible with celery 5

### DIFF
--- a/django_slack/tasks.py
+++ b/django_slack/tasks.py
@@ -1,11 +1,11 @@
-from celery import task
+from celery import shared_task
 
 from django.utils.module_loading import import_string
 
 from .app_settings import app_settings
 
 
-@task
+@shared_task
 def send(*args, **kwargs):
     backend = import_string(app_settings.BACKEND_FOR_QUEUE)()
 


### PR DESCRIPTION
Use a shared task decorator as this is a lib, not an app.
Please also consider properly adding the dependency to celery to the setup.py
Fix for #97