### PR TITLE
Make Python 3.6+ a hard requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setup(
     license="BSD-3-Clause",
     packages=find_packages(),
     include_package_data=True,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=('Django>=2', 'requests'),
 )


### PR DESCRIPTION
Support for Python 3.5 was dropped in https://github.com/lamby/django-slack/commit/cd8cce9360fdceb0cb1b4228ef71c0b80a212a4b.
Python 3.5 reached its EOL in September 2020, see https://www.python.org/dev/peps/pep-0478/.