### PR TITLE
Use setuptools package autodiscovery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
 setup(
     name='django-slack',
@@ -11,7 +11,6 @@ setup(
     author="Chris Lamb",
     author_email="chris@chris-lamb.co.uk",
     license="BSD-3-Clause",
-    packages=find_packages(),
     include_package_data=True,
     python_requires=">=3.6",
     install_requires=('Django>=3.2', 'requests'),


### PR DESCRIPTION
There is a packaging bug where the *tests* package is included in the built wheel. This happens because using find_packages() performs as expected and finds **all** packages, including the *tests* package.

<img width="1878" height="1204" alt="image" src="https://github.com/user-attachments/assets/a9ae5750-3111-432e-96bd-ec466530b076" />

This bug can either be solved by not making *tests* a package i.e. removing the `__init__.py` from the `tests/` dir. Or otherwise we can simply use setuptools [project autodiscovery](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#flat-layout). This autodiscovery will by default exclude any *tests* package. The latter is simpler and leaves the current tests structure intact, so choose that option.

The resulting wheel is exactly the same, minus the *tests* package.