### PR TITLE
Change intersphinx_mapping to new style config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,4 +23,4 @@ templates_path = ['_templates']
 latex_documents = [
     ('index', '%s.tex' % project, html_title, author, 'manual', True),
 ]
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}


### PR DESCRIPTION
The old style was removed in [Sphinx 8.0](https://www.sphinx-doc.org/en/master/changes/8.0.html) (released Jul 29, 2024).

Although, it might be the case that it isn't even used anymore. I kept it in to be sure.